### PR TITLE
Fix cli in dockerfiles/README.md

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -35,7 +35,7 @@
 The docker file supports both x86_64 and ARM64(aarch64). You may use docker's "--platform" parameter to explicitly specify which CPU architecture you want to build. For example:
 
 ```bash
-  docker build --platform linux/arm64/v8 -f Dockerfile.source
+  docker build --platform linux/arm64/v8 -f Dockerfile.source ..
 ```
 However, we cannot build the code for 32-bit ARM in such a way since a 32-bit compiler/linker might not have enough memory to generate the binaries.
 


### PR DESCRIPTION
Added context to command line example when specifying platform.

### Description
Docker image build fails due to missing context in the command line example when specifying the platform.

The dockerfiles directory is assumed as the current directory in the command example, so the parent directory must be specified as the context of the docker build command
